### PR TITLE
Update OpenSearch and Lucene versions to 3.1.0 and 10.2.1 with PluginInfo integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-runner</artifactId>
-	<version>3.0.0.1-SNAPSHOT</version>
+	<version>3.1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>OpenSearch Runner</name>
 	<description>OpenSearch Runner is a utility for running and managing OpenSearch clusters locally.</description>
@@ -36,8 +36,8 @@
   </scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<opensearch.version>3.0.0</opensearch.version>
-		<lucene.version>10.1.0</lucene.version>
+		<opensearch.version>3.1.0</opensearch.version>
+		<lucene.version>10.2.1</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<jna.version>5.16.0</jna.version>
 		<jts-core.version>1.15.0</jts-core.version>


### PR DESCRIPTION
This update upgrades the OpenSearch dependency from 3.0.0 to 3.1.0 and Lucene from 10.1.0 to 10.2.1. It also modifies the OpenSearchRunnerNode constructor to explicitly create PluginInfo instances for each classpath plugin, aligning with the updated plugin initialization requirements introduced in OpenSearch 3.1.0.
