### PR TITLE
Bump OpenSearch Runner to 3.2.0 with updated Lucene dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ es_home/
 .classpath
 .project
 .idea
+.serena/

--- a/README.md
+++ b/README.md
@@ -1,92 +1,410 @@
-OpenSearch Runner
+# OpenSearch Runner
+
 [![Java CI with Maven](https://github.com/codelibs/opensearch-runner/actions/workflows/maven.yml/badge.svg)](https://github.com/codelibs/opensearch-runner/actions/workflows/maven.yml)
-============
+[![Maven Central](https://img.shields.io/maven-central/v/org.codelibs.opensearch/opensearch-runner.svg)](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-runner/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This project runs OpenSearch cluster on one JVM instance for your development/testing easily.
-You can use OpenSearch Runner as Embedded OpenSearch in your application.
+## Overview
 
-## Version
+OpenSearch Runner is a utility library that allows you to run OpenSearch clusters on a single JVM instance for development and testing purposes. It provides an easy way to programmatically start, manage, and interact with OpenSearch nodes without complex setup.
 
-[Versions in Maven Repository](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-runner/)
+### Key Features
 
-## Run on Your Application
+- **Single JVM Execution**: Run multiple OpenSearch nodes in a single JVM process
+- **Embedded Usage**: Use as an embedded OpenSearch instance in your application
+- **Testing Support**: Perfect for integration tests and development
+- **Flexible Configuration**: Customize cluster settings, ports, and paths
+- **Module & Plugin Support**: Load OpenSearch modules and plugins dynamically
+- **Cluster Management**: Easy APIs for common operations (indexing, searching, cluster health)
 
-Put opensearch-runner if using Maven:
+## Requirements
 
-    <dependency>
-        <groupId>org.codelibs.opensearch</groupId>
-        <artifactId>opensearch-runner</artifactId>
-        <version>x.x.x.0</version>
-    </dependency>
+- Java 21 or higher
+- Maven 3.6 or higher
+- OpenSearch 3.2.0 (current development version)
 
-### Start Runner
+## Installation
 
-    import static org.codelibs.opensearch.runner.OpenSearchRunner.newConfigs;
-    ...
-    // create runner instance
-    OpenSearchRunner runner = new OpenSearchRunner();
-    // create ES nodes
-    runner.onBuild(new OpenSearchRunner.Builder() {
-        @Override
-        public void build(final int number, final Builder settingsBuilder) {
-            // put opensearch settings
-            // settingsBuilder.put("index.number_of_replicas", 0);
-        }
-    }).build(newConfigs());
+### Maven
 
-build(Configs) method configures/starts Clsuter Runner.
+Add the following dependency to your `pom.xml`:
 
-### Stop Runner
+```xml
+<dependency>
+    <groupId>org.codelibs.opensearch</groupId>
+    <artifactId>opensearch-runner</artifactId>
+    <version>3.2.0.0</version>
+</dependency>
+```
 
-    // close runner
-    runner.close();
+For testing purposes, use `test` scope:
 
-### Clean up 
+```xml
+<dependency>
+    <groupId>org.codelibs.opensearch</groupId>
+    <artifactId>opensearch-runner</artifactId>
+    <version>3.2.0.0</version>
+    <scope>test</scope>
+</dependency>
+```
 
-    // delete all files(config and index)
-    runner.clean();
+### Gradle
 
-## Run on JUnit
+```gradle
+implementation 'org.codelibs.opensearch:opensearch-runner:3.2.0.0'
 
-Put opensearch-runner as test scope:
+// For testing
+testImplementation 'org.codelibs.opensearch:opensearch-runner:3.2.0.0'
+```
 
-    <dependency>
-        <groupId>org.codelibs.opensearch</groupId>
-        <artifactId>opensearch-runner</artifactId>
-        <version>x.x.x.0</version>
-        <scope>test</scope>
-    </dependency>
+## Quick Start
 
-and see [OpenSearchRunnerTest](https://github.com/codelibs/opensearch-runner/blob/master/src/test/java/org/codelibs/opensearch/runner/OpenSearchRunnerTest.java "OpenSearchRunnerTest").
+### Basic Usage
 
-## Run as Standalone
+```java
+import static org.codelibs.opensearch.runner.OpenSearchRunner.newConfigs;
+import org.codelibs.opensearch.runner.OpenSearchRunner;
 
-### Install Maven
+// Create and start a single-node cluster
+OpenSearchRunner runner = new OpenSearchRunner();
+runner.build(newConfigs());
 
-Download and install Maven 3 from http://maven.apache.org/.
+// Perform operations
+runner.createIndex("my-index", null);
+runner.insert("my-index", "1", "{ \"name\": \"OpenSearch\" }");
 
-### Clone This Project
+// Clean up
+runner.close();
+runner.clean(); // Optional: delete all data
+```
 
-    git clone https://github.com/codelibs/opensearch-runner.git
+### Custom Configuration
 
-### Build This Project
+```java
+// Configure a 3-node cluster with custom settings
+OpenSearchRunner runner = new OpenSearchRunner();
+runner.onBuild(new OpenSearchRunner.Builder() {
+    @Override
+    public void build(int nodeNumber, Settings.Builder settingsBuilder) {
+        // Customize settings for each node
+        settingsBuilder.put("index.number_of_replicas", 1);
+        settingsBuilder.put("index.number_of_shards", 3);
+    }
+}).build(newConfigs()
+    .numOfNode(3)
+    .baseHttpPort(9201)
+    .clusterName("my-test-cluster")
+    .basePath("/tmp/opensearch"));
+```
 
-    mvn compile
+## API Reference
 
-## Run/Stop OpenSearch Cluster
+### Cluster Management
+
+```java
+// Start/stop operations
+runner.build(configs);           // Build and start cluster
+runner.startNode(nodeIndex);     // Start specific node
+runner.close();                  // Stop all nodes
+runner.clean();                  // Delete all data files
+
+// Node access
+Node node = runner.node();                    // Get any node
+Node clusterManager = runner.clusterManagerNode(); // Get cluster manager node
+Node nonClusterManager = runner.nonClusterManagerNode(); // Get data node
+Client client = runner.client();              // Get OpenSearch client
+
+// Cluster health
+runner.ensureGreen();            // Wait for green status
+runner.ensureYellow();           // Wait for yellow status
+runner.waitForRelocation();      // Wait for shard relocation
+```
+
+### Index Operations
+
+```java
+// Index management
+runner.createIndex("index-name", settings);
+runner.deleteIndex("index-name");
+runner.indexExists("index-name");
+runner.openIndex("index-name");
+runner.closeIndex("index-name");
+
+// Mappings
+runner.createMapping("index-name", mappingJson);
+runner.createMapping("index-name", xContentBuilder);
+
+// Aliases
+runner.getAlias("alias-name");
+runner.updateAlias("alias-name", addIndices, removeIndices);
+```
+
+### Document Operations
+
+```java
+// CRUD operations
+runner.insert("index", "id", "{ \"field\": \"value\" }");
+runner.delete("index", "id");
+runner.count("index");
+
+// Search
+SearchResponse response = runner.search("index", queryBuilder, 
+    sortBuilder, from, size);
+
+// Using callback for advanced queries
+runner.search("index", builder -> {
+    builder.setQuery(QueryBuilders.matchAllQuery())
+           .addSort("timestamp", SortOrder.DESC)
+           .setSize(100);
+});
+```
+
+### Maintenance Operations
+
+```java
+// Flush, refresh, and optimization
+runner.flush();
+runner.refresh();
+runner.forceMerge();
+runner.upgrade();
+
+// Custom configurations
+runner.flush(builder -> {
+    builder.setIndices("index1", "index2")
+           .setForce(true);
+});
+```
+
+## Testing with JUnit
+
+### JUnit 4 Example
+
+```java
+public class MyOpenSearchTest {
+    private OpenSearchRunner runner;
+
+    @Before
+    public void setUp() throws Exception {
+        runner = new OpenSearchRunner();
+        runner.onBuild((number, settingsBuilder) -> {
+            settingsBuilder.put("http.cors.enabled", true);
+        }).build(newConfigs());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        runner.close();
+        runner.clean();
+    }
+
+    @Test
+    public void testIndexing() throws Exception {
+        String index = "test-index";
+        
+        runner.createIndex(index, null);
+        runner.insert(index, "1", "{ \"message\": \"test\" }");
+        runner.refresh();
+        
+        assertEquals(1, runner.count(index));
+    }
+}
+```
+
+### JUnit 5 Example
+
+```java
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MyOpenSearchTest {
+    private OpenSearchRunner runner;
+
+    @BeforeAll
+    void setUp() {
+        runner = new OpenSearchRunner();
+        runner.build(newConfigs()
+            .numOfNode(1)
+            .baseHttpPort(9201));
+    }
+
+    @AfterAll
+    void tearDown() {
+        runner.close();
+        runner.clean();
+    }
+
+    @Test
+    void testSearch() {
+        // Your test code here
+    }
+}
+```
+
+## Standalone Execution
+
+### Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/codelibs/opensearch-runner.git
+cd opensearch-runner
+
+# Build the project
+mvn compile
+```
 
 ### Run Cluster
 
-Run:
+```bash
+# Start with default configuration (3 nodes)
+mvn exec:java
 
-    mvn exec:java 
+# Custom configuration
+mvn exec:java -Dexec.args="-basePath /tmp/opensearch -numOfNode 5"
 
-The default cluster has 3 nodes and the root directory for OpenSearch is es\_home.
-Nodes use 9201-9203 port for HTTP and 9301-9303 port for Transport.
-If you want to change the number of node, Run:
+# Available options:
+# -basePath <path>     : Base directory for OpenSearch data (default: es_home)
+# -numOfNode <number>  : Number of nodes to start (default: 3)
+```
 
-    mvn exec:java -Dexec.args="-basePath es_home -numOfNode 4"
+Default ports:
+- HTTP: 9201-9203 (for 3 nodes)
+- Transport: 9301-9303 (for 3 nodes)
 
 ### Stop Cluster
 
-Type Ctrl-c or kill the process.
+Press `Ctrl+C` or kill the process to stop the cluster.
+
+## Configuration Options
+
+### Configs Builder
+
+The `Configs` class provides a fluent API for configuration:
+
+```java
+newConfigs()
+    .basePath("/path/to/data")           // Base directory
+    .numOfNode(3)                        // Number of nodes
+    .baseHttpPort(9201)                  // Starting HTTP port
+    .clusterName("my-cluster")           // Cluster name
+    .indexStoreType("niofs")             // Index store type
+    .moduleTypes("org.opensearch.analysis.common.CommonAnalysisPlugin")
+    .pluginTypes("com.example.MyPlugin")
+    .disableESLogger()                   // Disable OpenSearch logging
+    .printOnFailure()                    // Print errors on failure
+    .useLogger();                        // Enable logging
+```
+
+### Settings Builder
+
+Customize OpenSearch settings per node:
+
+```java
+runner.onBuild((nodeNumber, settingsBuilder) -> {
+    // Node-specific settings
+    settingsBuilder.put("node.name", "node-" + nodeNumber);
+    
+    // Security settings
+    settingsBuilder.put("plugins.security.disabled", true);
+    
+    // Network settings
+    settingsBuilder.put("network.host", "127.0.0.1");
+    
+    // Discovery settings
+    settingsBuilder.put("discovery.type", "single-node");
+});
+```
+
+## Advanced Features
+
+### Custom Modules and Plugins
+
+```java
+// Load custom modules
+runner.build(newConfigs()
+    .moduleTypes(
+        "org.opensearch.analysis.common.CommonAnalysisPlugin",
+        "org.opensearch.index.reindex.ReindexPlugin"
+    ));
+
+// Load custom plugins
+runner.build(newConfigs()
+    .pluginTypes("com.example.MyCustomPlugin"));
+```
+
+### Working with Multiple Nodes
+
+```java
+// Access specific nodes
+for (int i = 0; i < runner.getNodeSize(); i++) {
+    Node node = runner.getNode(i);
+    // Perform node-specific operations
+}
+
+// Get node by name
+Node namedNode = runner.getNode("node-1");
+```
+
+### HTTP Client Integration
+
+```java
+// Use with OpenSearchCurl for HTTP operations
+String response = OpenSearchCurl.get(node, "/_cluster/health");
+String indexResponse = OpenSearchCurl.post(node, "/my-index/_doc/1", 
+    "{ \"field\": \"value\" }");
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Port Already in Use**: Change the base HTTP port using `.baseHttpPort(9250)`
+2. **Permission Denied**: Ensure write permissions for the base path directory
+3. **Memory Issues**: Increase JVM heap size with `-Xmx2g`
+4. **Plugin Loading**: Verify plugin classes are in the classpath
+
+### Logging
+
+Enable detailed logging for debugging:
+
+```java
+runner.build(newConfigs()
+    .useLogger()           // Enable runner logging
+    .printOnFailure());    // Print stack traces on failure
+```
+
+Configure Log4j2 by placing a `log4j2.properties` file in your classpath.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+
+### Development
+
+```bash
+# Run tests
+mvn test
+
+# Run specific test
+mvn test -Dtest=OpenSearchRunnerTest#test_runCluster
+
+# Build package
+mvn package
+
+# Install to local repository
+mvn install
+```
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/codelibs/opensearch-runner/issues)
+- **Documentation**: [API Documentation](https://codelibs.github.io/opensearch-runner/)
+- **Examples**: See [test cases](src/test/java/org/codelibs/opensearch/runner/) for more examples
+
+## Related Projects
+
+- [OpenSearch](https://opensearch.org/) - The OpenSearch project
+- [TestContainers](https://www.testcontainers.org/) - Alternative for integration testing
+

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-runner</artifactId>
-	<version>3.1.0.1-SNAPSHOT</version>
+	<version>3.2.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>OpenSearch Runner</name>
 	<description>OpenSearch Runner is a utility for running and managing OpenSearch clusters locally.</description>
@@ -36,8 +36,8 @@
   </scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<opensearch.version>3.1.0</opensearch.version>
-		<lucene.version>10.2.1</lucene.version>
+		<opensearch.version>3.2.0</opensearch.version>
+		<lucene.version>10.2.2</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<jna.version>5.16.0</jna.version>
 		<jts-core.version>1.15.0</jts-core.version>


### PR DESCRIPTION
This update upgrades the project to the next snapshot version 3.2.0.0-SNAPSHOT.
Key changes include:

- Upgraded OpenSearch version from 3.1.0 → 3.2.0
- Upgraded Lucene version from 10.2.1 → 10.2.2

These changes align the project with the latest upstream OpenSearch release and ensure compatibility with the updated Lucene library.