### PR TITLE
Add comprehensive Javadoc documentation to OpenSearch Runner classes

### DIFF
--- a/src/main/java/org/codelibs/opensearch/runner/OpenSearchRunner.java
+++ b/src/main/java/org/codelibs/opensearch/runner/OpenSearchRunner.java
@@ -115,10 +115,13 @@ public class OpenSearchRunner implements Closeable {
 
     private static final String NODE_NAME = "node.name";
 
+    /** Configuration file name for Log4j2 properties. */
     protected static final String LOG4J2_PROPERTIES = "log4j2.properties";
 
+    /** Configuration file name for OpenSearch YAML settings. */
     protected static final String ELASTICSEARCH_YAML = "opensearch.yml";
 
+    /** Default module types to load in the OpenSearch cluster. */
     protected static final String[] MODULE_TYPES = { //
             "org.opensearch.search.aggregations.matrix.MatrixAggregationModulePlugin", //
             "org.opensearch.analysis.common.CommonAnalysisModulePlugin", //
@@ -142,63 +145,90 @@ public class OpenSearchRunner implements Closeable {
             "org.opensearch.transport.Netty4ModulePlugin" //
     };
 
+    /** Default directory name for data storage. */
     protected static final String DATA_DIR = "data";
 
+    /** Default directory name for log storage. */
     protected static final String LOGS_DIR = "logs";
 
+    /** Default directory name for configuration files. */
     protected static final String CONFIG_DIR = "config";
 
+    /** List of OpenSearch nodes in the cluster. */
     protected List<OpenSearchRunnerNode> nodeList = new ArrayList<>();
 
+    /** List of environment configurations for each node. */
     protected List<Environment> envList = new ArrayList<>();
 
+    /** Collection of module classes to load. */
     protected Collection<Class<? extends Plugin>> moduleList = new ArrayList<>();
 
+    /** Collection of plugin classes to load. */
     protected Collection<Class<? extends Plugin>> pluginList = new ArrayList<>();
 
+    /** Maximum HTTP port number for node discovery. */
     protected int maxHttpPort = 9299;
 
+    /** Base path for OpenSearch data and configuration files. */
     @Option(name = "-basePath", usage = "Base path for OpenSearch.")
     protected String basePath;
 
+    /** Path to configuration files directory. */
     @Option(name = "-confPath", usage = "Config path for OpenSearch.")
     protected String confPath;
 
+    /** Path to data storage directory. */
     @Option(name = "-dataPath", usage = "Data path for OpenSearch.")
     protected String dataPath;
 
+    /** Path to logs directory. */
     @Option(name = "-logsPath", usage = "Log path for OpenSearch.")
     protected String logsPath;
 
+    /** Number of nodes to create in the cluster. */
     @Option(name = "-numOfNode", usage = "The number of OpenSearch node.")
     protected int numOfNode = 3;
 
+    /** Base HTTP port number for the first node. */
     @Option(name = "-baseHttpPort", usage = "Base http port.")
     protected int baseHttpPort = 9200;
 
+    /** Name of the OpenSearch cluster. */
     @Option(name = "-clusterName", usage = "Cluster name.")
     protected String clusterName = "opensearch-runner";
 
+    /** Type of index store to use (e.g., 'fs' for filesystem). */
     @Option(name = "-indexStoreType", usage = "Index store type.")
     protected String indexStoreType = "fs";
 
+    /** Whether to use logger for output instead of System.out. */
     @Option(name = "-useLogger", usage = "Print logs to a logger.")
     protected boolean useLogger = false;
 
+    /** Whether to disable OpenSearch internal logging. */
     @Option(name = "-disableESLogger", usage = "Disable ESLogger.")
     protected boolean disableESLogger = false;
 
+    /** Whether to print stack traces on operation failures. */
     @Option(name = "-printOnFailure", usage = "Print an exception on a failure.")
     protected boolean printOnFailure = false;
 
+    /** Comma-separated list of module types to load. */
     @Option(name = "-moduleTypes", usage = "Module types.")
     protected String moduleTypes;
 
+    /** Comma-separated list of plugin types to load. */
     @Option(name = "-pluginTypes", usage = "Plugin types.")
     protected String pluginTypes;
 
+    /** Custom settings builder for node configuration. */
     protected Builder settingsBuilder;
 
+    /**
+     * Main method to run OpenSearch cluster from command line.
+     *
+     * @param args command line arguments
+     */
     public static void main(final String[] args) {
         try (final OpenSearchRunner runner = new OpenSearchRunner()) {
             Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -225,6 +255,9 @@ public class OpenSearchRunner implements Closeable {
         }
     }
 
+    /**
+     * Constructs a new OpenSearchRunner instance with default settings.
+     */
     public OpenSearchRunner() {
         // nothing
     }
@@ -383,6 +416,11 @@ public class OpenSearchRunner implements Closeable {
         }
     }
 
+    /**
+     * Executes the setup and start process for a node with the specified ID.
+     *
+     * @param id the node ID
+     */
     protected void execute(final int id) {
         final Path homePath = Paths.get(basePath, "node_" + id);
         final Path confPath = this.confPath == null
@@ -532,6 +570,12 @@ public class OpenSearchRunner implements Closeable {
         }
     }
 
+    /**
+     * Gets an available HTTP port starting from the base port plus the node number.
+     *
+     * @param number the node number
+     * @return an available HTTP port number
+     */
     protected int getAvailableHttpPort(final int number) {
         int httpPort = baseHttpPort + number;
         if (maxHttpPort < 0) {
@@ -551,6 +595,13 @@ public class OpenSearchRunner implements Closeable {
                 "The http port " + httpPort + " is unavailable.");
     }
 
+    /**
+     * Adds a setting to the builder if it's not already present.
+     *
+     * @param builder the settings builder
+     * @param key the setting key
+     * @param value the setting value
+     */
     protected void putIfAbsent(final Settings.Builder builder, final String key,
             final String value) {
         if (builder.get(key) == null && value != null) {
@@ -558,6 +609,11 @@ public class OpenSearchRunner implements Closeable {
         }
     }
 
+    /**
+     * Sets the maximum HTTP port for node discovery.
+     *
+     * @param maxHttpPort the maximum HTTP port number
+     */
     public void setMaxHttpPort(final int maxHttpPort) {
         this.maxHttpPort = maxHttpPort;
     }
@@ -639,6 +695,11 @@ public class OpenSearchRunner implements Closeable {
         return nodeList.size();
     }
 
+    /**
+     * Prints a message using the configured output method.
+     *
+     * @param line the message to print
+     */
     public void print(final String line) {
         if (useLogger) {
             logger.info(line);
@@ -647,6 +708,11 @@ public class OpenSearchRunner implements Closeable {
         }
     }
 
+    /**
+     * Creates a directory at the specified path if it doesn't exist.
+     *
+     * @param path the directory path to create
+     */
     protected void createDir(final Path path) {
         if (!path.toFile().exists()) {
             print("Creating " + path);
@@ -769,6 +835,11 @@ public class OpenSearchRunner implements Closeable {
         return actionGet.getStatus();
     }
 
+    /**
+     * Waits for shard relocation to complete.
+     *
+     * @return the cluster health status after relocation
+     */
     public ClusterHealthStatus waitForRelocation() {
         final ClusterHealthRequest request = Requests.clusterHealthRequest()
                 .waitForNoRelocatingShards(true);
@@ -787,14 +858,31 @@ public class OpenSearchRunner implements Closeable {
         return actionGet.getStatus();
     }
 
+    /**
+     * Flushes all indices in the cluster.
+     *
+     * @return flush response
+     */
     public FlushResponse flush() {
         return flush(true);
     }
 
+    /**
+     * Flushes all indices in the cluster with force option.
+     *
+     * @param force whether to force the flush
+     * @return flush response
+     */
     public FlushResponse flush(final boolean force) {
         return flush(builder -> builder.setWaitIfOngoing(true).setForce(force));
     }
 
+    /**
+     * Flushes indices with custom flush configuration.
+     *
+     * @param builder callback to configure the flush request
+     * @return flush response
+     */
     public FlushResponse flush(
             final BuilderCallback<FlushRequestBuilder> builder) {
         waitForRelocation();
@@ -813,10 +901,21 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Refreshes all indices in the cluster.
+     *
+     * @return refresh response
+     */
     public RefreshResponse refresh() {
         return refresh(builder -> builder);
     }
 
+    /**
+     * Refreshes indices with custom refresh configuration.
+     *
+     * @param builder callback to configure the refresh request
+     * @return refresh response
+     */
     public RefreshResponse refresh(
             final BuilderCallback<RefreshRequestBuilder> builder) {
         waitForRelocation();
@@ -835,15 +934,32 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Upgrades all indices in the cluster.
+     *
+     * @return upgrade response
+     */
     public UpgradeResponse upgrade() {
         return upgrade(true);
     }
 
+    /**
+     * Upgrades all indices with option to upgrade only ancient segments.
+     *
+     * @param upgradeOnlyAncientSegments whether to upgrade only ancient segments
+     * @return upgrade response
+     */
     public UpgradeResponse upgrade(final boolean upgradeOnlyAncientSegments) {
         return upgrade(builder -> builder
                 .setUpgradeOnlyAncientSegments(upgradeOnlyAncientSegments));
     }
 
+    /**
+     * Upgrades indices with custom upgrade configuration.
+     *
+     * @param builder callback to configure the upgrade request
+     * @return upgrade response
+     */
     public UpgradeResponse upgrade(
             final BuilderCallback<UpgradeRequestBuilder> builder) {
         waitForRelocation();
@@ -862,16 +978,35 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Force merges all indices in the cluster.
+     *
+     * @return force merge response
+     */
     public ForceMergeResponse forceMerge() {
         return forceMerge(-1, false, true);
     }
 
+    /**
+     * Force merges indices with specified parameters.
+     *
+     * @param maxNumSegments maximum number of segments per shard
+     * @param onlyExpungeDeletes whether to only expunge deleted documents
+     * @param flush whether to flush after the merge
+     * @return force merge response
+     */
     public ForceMergeResponse forceMerge(final int maxNumSegments,
             final boolean onlyExpungeDeletes, final boolean flush) {
         return forceMerge(builder -> builder.setMaxNumSegments(maxNumSegments)
                 .setOnlyExpungeDeletes(onlyExpungeDeletes).setFlush(flush));
     }
 
+    /**
+     * Force merges indices with custom configuration.
+     *
+     * @param builder callback to configure the force merge request
+     * @return force merge response
+     */
     public ForceMergeResponse forceMerge(
             final BuilderCallback<ForceMergeRequestBuilder> builder) {
         waitForRelocation();
@@ -890,10 +1025,23 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Opens the specified index.
+     *
+     * @param index the index name to open
+     * @return open index response
+     */
     public OpenIndexResponse openIndex(final String index) {
         return openIndex(index, builder -> builder);
     }
 
+    /**
+     * Opens the specified index with custom request configuration.
+     *
+     * @param index the index name to open
+     * @param builder callback to configure the open index request
+     * @return open index response
+     */
     public OpenIndexResponse openIndex(final String index,
             final BuilderCallback<OpenIndexRequestBuilder> builder) {
         final OpenIndexResponse actionGet = builder
@@ -905,10 +1053,23 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Closes the specified index.
+     *
+     * @param index the index name to close
+     * @return the close index response
+     */
     public CloseIndexResponse closeIndex(final String index) {
         return closeIndex(index, builder -> builder);
     }
 
+    /**
+     * Closes the specified index with custom request configuration.
+     *
+     * @param index the index name to close
+     * @param builder callback to configure the close index request
+     * @return the close index response
+     */
     public CloseIndexResponse closeIndex(final String index,
             final BuilderCallback<CloseIndexRequestBuilder> builder) {
         final CloseIndexResponse actionGet = builder
@@ -920,12 +1081,26 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Creates an index with the specified settings.
+     *
+     * @param index the index name to create
+     * @param settings the index settings
+     * @return create index response
+     */
     public CreateIndexResponse createIndex(final String index,
             final Settings settings) {
         return createIndex(index, builder -> builder.setSettings(
                 settings != null ? settings : Settings.Builder.EMPTY_SETTINGS));
     }
 
+    /**
+     * Creates an index with custom configuration.
+     *
+     * @param index the index name to create
+     * @param builder callback to configure the create index request
+     * @return create index response
+     */
     public CreateIndexResponse createIndex(final String index,
             final BuilderCallback<CreateIndexRequestBuilder> builder) {
         final CreateIndexResponse actionGet = builder
@@ -937,10 +1112,23 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Checks if the specified index exists.
+     *
+     * @param index the index name to check
+     * @return true if the index exists, false otherwise
+     */
     public boolean indexExists(final String index) {
         return indexExists(index, builder -> builder);
     }
 
+    /**
+     * Checks if the specified index exists with custom configuration.
+     *
+     * @param index the index name to check
+     * @param builder callback to configure the indices exists request
+     * @return true if the index exists, false otherwise
+     */
     public boolean indexExists(final String index,
             final BuilderCallback<IndicesExistsRequestBuilder> builder) {
         final IndicesExistsResponse actionGet = builder
@@ -949,10 +1137,23 @@ public class OpenSearchRunner implements Closeable {
         return actionGet.isExists();
     }
 
+    /**
+     * Deletes the specified index.
+     *
+     * @param index the index name to delete
+     * @return acknowledged response
+     */
     public AcknowledgedResponse deleteIndex(final String index) {
         return deleteIndex(index, builder -> builder);
     }
 
+    /**
+     * Deletes the specified index with custom configuration.
+     *
+     * @param index the index name to delete
+     * @param builder callback to configure the delete index request
+     * @return acknowledged response
+     */
     public AcknowledgedResponse deleteIndex(final String index,
             final BuilderCallback<DeleteIndexRequestBuilder> builder) {
         final AcknowledgedResponse actionGet = builder
@@ -964,17 +1165,38 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Creates mapping for the specified index.
+     *
+     * @param index the index name
+     * @param mappingSource the mapping definition as JSON string
+     * @return acknowledged response
+     */
     public AcknowledgedResponse createMapping(final String index,
             final String mappingSource) {
         return createMapping(index, builder -> builder.setSource(mappingSource,
                 xContentType(mappingSource)));
     }
 
+    /**
+     * Creates mapping for the specified index using XContentBuilder.
+     *
+     * @param index the index name
+     * @param source the mapping definition as XContentBuilder
+     * @return acknowledged response
+     */
     public AcknowledgedResponse createMapping(final String index,
             final XContentBuilder source) {
         return createMapping(index, builder -> builder.setSource(source));
     }
 
+    /**
+     * Creates mapping for the specified index with custom configuration.
+     *
+     * @param index the index name
+     * @param builder callback to configure the put mapping request
+     * @return acknowledged response
+     */
     public AcknowledgedResponse createMapping(final String index,
             final BuilderCallback<PutMappingRequestBuilder> builder) {
         final AcknowledgedResponse actionGet = builder
@@ -987,6 +1209,14 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Inserts a document into the specified index.
+     *
+     * @param index the index name
+     * @param id the document ID
+     * @param source the document source
+     * @return index response
+     */
     public IndexResponse insert(final String index, final String id,
             final String source) {
         return insert(index, id,
@@ -994,6 +1224,14 @@ public class OpenSearchRunner implements Closeable {
                         .setRefreshPolicy(RefreshPolicy.IMMEDIATE));
     }
 
+    /**
+     * Inserts a document into the specified index with custom configuration.
+     *
+     * @param index the index name
+     * @param id the document ID
+     * @param builder callback to configure the index request
+     * @return index response
+     */
     public IndexResponse insert(final String index, final String id,
             final BuilderCallback<IndexRequestBuilder> builder) {
         final IndexResponse actionGet = builder
@@ -1006,11 +1244,26 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Deletes a document from the specified index.
+     *
+     * @param index the index name
+     * @param id the document ID
+     * @return delete response
+     */
     public DeleteResponse delete(final String index, final String id) {
         return delete(index, id,
                 builder -> builder.setRefreshPolicy(RefreshPolicy.IMMEDIATE));
     }
 
+    /**
+     * Deletes a document from the specified index with custom configuration.
+     *
+     * @param index the index name
+     * @param id the document ID
+     * @param builder callback to configure the delete request
+     * @return delete response
+     */
     public DeleteResponse delete(final String index, final String id,
             final BuilderCallback<DeleteRequestBuilder> builder) {
         final DeleteResponse actionGet = builder
@@ -1023,16 +1276,39 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Counts documents in the specified index.
+     *
+     * @param index the index name
+     * @return search response containing the count
+     */
     public SearchResponse count(final String index) {
         return count(index, builder -> builder);
     }
 
+    /**
+     * Counts documents in the specified index with custom search configuration.
+     *
+     * @param index the index name
+     * @param builder callback to configure the search request
+     * @return search response containing the count
+     */
     public SearchResponse count(final String index,
             final BuilderCallback<SearchRequestBuilder> builder) {
         return builder.apply(client().prepareSearch(index).setSize(0)).execute()
                 .actionGet();
     }
 
+    /**
+     * Searches documents in the specified index with query, sort, and pagination parameters.
+     *
+     * @param index the index name
+     * @param queryBuilder the query to execute
+     * @param sort the sort configuration
+     * @param from the starting position for results
+     * @param size the number of results to return
+     * @return search response containing the results
+     */
     public SearchResponse search(final String index,
             final QueryBuilder queryBuilder, final SortBuilder<?> sort,
             final int from, final int size) {
@@ -1044,16 +1320,36 @@ public class OpenSearchRunner implements Closeable {
                         .setFrom(from).setSize(size));
     }
 
+    /**
+     * Searches documents in the specified index with custom search configuration.
+     *
+     * @param index the index name
+     * @param builder callback to configure the search request
+     * @return search response containing the results
+     */
     public SearchResponse search(final String index,
             final BuilderCallback<SearchRequestBuilder> builder) {
         return builder.apply(client().prepareSearch(index)).execute()
                 .actionGet();
     }
 
+    /**
+     * Gets information about the specified alias.
+     *
+     * @param alias the alias name
+     * @return get aliases response
+     */
     public GetAliasesResponse getAlias(final String alias) {
         return getAlias(alias, builder -> builder);
     }
 
+    /**
+     * Gets information about the specified alias with custom configuration.
+     *
+     * @param alias the alias name
+     * @param builder callback to configure the get aliases request
+     * @return get aliases response
+     */
     public GetAliasesResponse getAlias(final String alias,
             final BuilderCallback<GetAliasesRequestBuilder> builder) {
         return builder
@@ -1061,6 +1357,14 @@ public class OpenSearchRunner implements Closeable {
                 .execute().actionGet();
     }
 
+    /**
+     * Updates an alias by adding and removing indices.
+     *
+     * @param alias the alias name
+     * @param addedIndices indices to add to the alias
+     * @param deletedIndices indices to remove from the alias
+     * @return acknowledged response
+     */
     public AcknowledgedResponse updateAlias(final String alias,
             final String[] addedIndices, final String[] deletedIndices) {
         return updateAlias(builder -> {
@@ -1074,6 +1378,12 @@ public class OpenSearchRunner implements Closeable {
         });
     }
 
+    /**
+     * Updates aliases with custom configuration.
+     *
+     * @param builder callback to configure the indices aliases request
+     * @return acknowledged response
+     */
     public AcknowledgedResponse updateAlias(
             final BuilderCallback<IndicesAliasesRequestBuilder> builder) {
         final AcknowledgedResponse actionGet = builder
@@ -1085,15 +1395,32 @@ public class OpenSearchRunner implements Closeable {
         return actionGet;
     }
 
+    /**
+     * Gets the cluster service instance.
+     *
+     * @return the ClusterService instance
+     */
     public ClusterService clusterService() {
         return getInstance(ClusterService.class);
     }
 
+    /**
+     * Gets an instance of the specified service class from the first available node.
+     *
+     * @param <T> the service type
+     * @param clazz the service class
+     * @return the service instance
+     */
     public synchronized <T> T getInstance(final Class<T> clazz) {
         final Node node = clusterManagerNode();
         return node.injector().getInstance(clazz);
     }
 
+    /**
+     * Gets the name of the cluster.
+     *
+     * @return the cluster name
+     */
     public String getClusterName() {
         return clusterName;
     }
@@ -1166,80 +1493,155 @@ public class OpenSearchRunner implements Closeable {
     public interface Builder {
 
         /**
+         * Configures settings for a specific node.
+         *
          * @param index an index of nodes
          * @param builder a builder instance to create a node
          */
         void build(int index, Settings.Builder builder);
     }
 
+    /**
+     * Creates a new configuration builder for OpenSearchRunner.
+     *
+     * @return a new Configs instance
+     */
     public static Configs newConfigs() {
         return new Configs();
     }
 
     /**
-     * OpenSearchRunner configuration.
-     *
+     * Configuration builder for OpenSearchRunner command line arguments.
      */
     public static class Configs {
         List<String> configList = new ArrayList<>();
 
+        /**
+         * Creates a new Configs instance for building OpenSearchRunner command line arguments.
+         */
+        public Configs() {
+            // Default constructor
+        }
+
+        /**
+         * Sets the base path for OpenSearch data and configuration files.
+         *
+         * @param basePath the base path
+         * @return this Configs instance for method chaining
+         */
         public Configs basePath(final String basePath) {
             configList.add("-basePath");
             configList.add(basePath);
             return this;
         }
 
+        /**
+         * Sets the number of nodes in the cluster.
+         *
+         * @param numOfNode the number of nodes
+         * @return this Configs instance for method chaining
+         */
         public Configs numOfNode(final int numOfNode) {
             configList.add("-numOfNode");
             configList.add(String.valueOf(numOfNode));
             return this;
         }
 
+        /**
+         * Sets the base HTTP port for the first node.
+         *
+         * @param baseHttpPort the base HTTP port
+         * @return this Configs instance for method chaining
+         */
         public Configs baseHttpPort(final int baseHttpPort) {
             configList.add("-baseHttpPort");
             configList.add(String.valueOf(baseHttpPort));
             return this;
         }
 
+        /**
+         * Sets the cluster name.
+         *
+         * @param clusterName the cluster name
+         * @return this Configs instance for method chaining
+         */
         public Configs clusterName(final String clusterName) {
             configList.add("-clusterName");
             configList.add(clusterName);
             return this;
         }
 
+        /**
+         * Sets the index store type.
+         *
+         * @param indexStoreType the index store type (e.g., 'fs')
+         * @return this Configs instance for method chaining
+         */
         public Configs indexStoreType(final String indexStoreType) {
             configList.add("-indexStoreType");
             configList.add(indexStoreType);
             return this;
         }
 
+        /**
+         * Enables logger output instead of System.out.
+         *
+         * @return this Configs instance for method chaining
+         */
         public Configs useLogger() {
             configList.add("-useLogger");
             return this;
         }
 
+        /**
+         * Disables OpenSearch internal logging.
+         *
+         * @return this Configs instance for method chaining
+         */
         public Configs disableESLogger() {
             configList.add("-disableESLogger");
             return this;
         }
 
+        /**
+         * Enables printing stack traces on operation failures.
+         *
+         * @return this Configs instance for method chaining
+         */
         public Configs printOnFailure() {
             configList.add("-printOnFailure");
             return this;
         }
 
+        /**
+         * Sets the module types to load.
+         *
+         * @param moduleTypes comma-separated list of module types
+         * @return this Configs instance for method chaining
+         */
         public Configs moduleTypes(final String moduleTypes) {
             configList.add("-moduleTypes");
             configList.add(moduleTypes);
             return this;
         }
 
+        /**
+         * Sets the plugin types to load.
+         *
+         * @param pluginTypes comma-separated list of plugin types
+         * @return this Configs instance for method chaining
+         */
         public Configs pluginTypes(final String pluginTypes) {
             configList.add("-pluginTypes");
             configList.add(pluginTypes);
             return this;
         }
 
+        /**
+         * Builds the configuration as a command line arguments array.
+         *
+         * @return array of command line arguments
+         */
         public String[] build() {
             return configList.toArray(new String[configList.size()]);
         }
@@ -1281,9 +1683,17 @@ public class OpenSearchRunner implements Closeable {
     }
 
     /**
-     * Callback function.
+     * Callback function for configuring request builders.
+     *
+     * @param <T> the type of builder to configure
      */
     public interface BuilderCallback<T> {
+        /**
+         * Applies configuration to the builder.
+         *
+         * @param builder the builder to configure
+         * @return the configured builder
+         */
         T apply(T builder);
     }
 }

--- a/src/main/java/org/codelibs/opensearch/runner/OpenSearchRunnerException.java
+++ b/src/main/java/org/codelibs/opensearch/runner/OpenSearchRunnerException.java
@@ -17,29 +17,55 @@ package org.codelibs.opensearch.runner;
 
 import org.opensearch.core.action.ActionResponse;
 
+/**
+ * Custom exception for OpenSearchRunner operations.
+ */
 public class OpenSearchRunnerException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
     private final transient ActionResponse response;
 
+    /**
+     * Constructs a new exception with the specified message and cause.
+     *
+     * @param message the detail message
+     * @param cause the cause of the exception
+     */
     public OpenSearchRunnerException(final String message,
             final Throwable cause) {
         super(message, cause);
         this.response = null;
     }
 
+    /**
+     * Constructs a new exception with the specified message.
+     *
+     * @param message the detail message
+     */
     public OpenSearchRunnerException(final String message) {
         super(message);
         this.response = null;
     }
 
+    /**
+     * Constructs a new exception with the specified message and response.
+     *
+     * @param message the detail message
+     * @param response the action response that caused the exception
+     */
     public OpenSearchRunnerException(final String message,
             final ActionResponse response) {
         super(message);
         this.response = response;
     }
 
+    /**
+     * Gets the action response associated with this exception.
+     *
+     * @param <T> the type of action response
+     * @return the action response, or null if none was provided
+     */
     @SuppressWarnings("unchecked")
     public <T extends ActionResponse> T getActionResponse() {
         return (T) response;

--- a/src/main/java/org/codelibs/opensearch/runner/net/OpenSearchCurl.java
+++ b/src/main/java/org/codelibs/opensearch/runner/net/OpenSearchCurl.java
@@ -28,28 +28,70 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.node.Node;
 
+/**
+ * HTTP client utilities for interacting with OpenSearch clusters.
+ * Provides convenience methods for creating cURL requests to OpenSearch nodes.
+ */
 public class OpenSearchCurl {
 
+    /**
+     * Protected constructor to prevent instantiation.
+     */
     protected OpenSearchCurl() {
         // nothing
     }
 
+    /**
+     * Creates a GET request to the specified OpenSearch node.
+     *
+     * @param node the OpenSearch node
+     * @param path the request path
+     * @return a CurlRequest configured for GET method
+     */
     public static CurlRequest get(final Node node, final String path) {
         return new CurlRequest(Method.GET, getUrl(node, path));
     }
 
+    /**
+     * Creates a POST request to the specified OpenSearch node.
+     *
+     * @param node the OpenSearch node
+     * @param path the request path
+     * @return a CurlRequest configured for POST method
+     */
     public static CurlRequest post(final Node node, final String path) {
         return new CurlRequest(Method.POST, getUrl(node, path));
     }
 
+    /**
+     * Creates a PUT request to the specified OpenSearch node.
+     *
+     * @param node the OpenSearch node
+     * @param path the request path
+     * @return a CurlRequest configured for PUT method
+     */
     public static CurlRequest put(final Node node, final String path) {
         return new CurlRequest(Method.PUT, getUrl(node, path));
     }
 
+    /**
+     * Creates a DELETE request to the specified OpenSearch node.
+     *
+     * @param node the OpenSearch node
+     * @param path the request path
+     * @return a CurlRequest configured for DELETE method
+     */
     public static CurlRequest delete(final Node node, final String path) {
         return new CurlRequest(Method.DELETE, getUrl(node, path));
     }
 
+    /**
+     * Constructs the URL for the given node and path.
+     *
+     * @param node the OpenSearch node
+     * @param path the request path
+     * @return the complete URL string
+     */
     protected static String getUrl(final Node node, final String path) {
         final StringBuilder urlBuf = new StringBuilder(200);
         urlBuf.append("http://localhost:")
@@ -62,26 +104,58 @@ public class OpenSearchCurl {
         return urlBuf.toString();
     }
 
+    /**
+     * Creates a GET request to the specified URL.
+     *
+     * @param url the target URL
+     * @return a CurlRequest configured for GET method
+     */
     public static CurlRequest get(final String url) {
         return new CurlRequest(Method.GET, url);
     }
 
+    /**
+     * Creates a POST request to the specified URL.
+     *
+     * @param url the target URL
+     * @return a CurlRequest configured for POST method
+     */
     public static CurlRequest post(final String url) {
         return new CurlRequest(Method.POST, url);
     }
 
+    /**
+     * Creates a PUT request to the specified URL.
+     *
+     * @param url the target URL
+     * @return a CurlRequest configured for PUT method
+     */
     public static CurlRequest put(final String url) {
         return new CurlRequest(Method.PUT, url);
     }
 
+    /**
+     * Creates a DELETE request to the specified URL.
+     *
+     * @param url the target URL
+     * @return a CurlRequest configured for DELETE method
+     */
     public static CurlRequest delete(final String url) {
         return new CurlRequest(Method.DELETE, url);
     }
 
+    /**
+     * Returns a JSON parser function for processing cURL responses.
+     *
+     * @return a function that parses JSON responses into Map objects
+     */
     public static Function<CurlResponse, Map<String, Object>> jsonParser() {
         return PARSER;
     }
 
+    /**
+     * JSON parser function that converts cURL responses to Map objects.
+     */
     protected static final Function<CurlResponse, Map<String, Object>> PARSER = response -> {
         try (InputStream is = response.getContentAsStream()) {
             return JsonXContent.jsonXContent

--- a/src/main/java/org/codelibs/opensearch/runner/node/OpenSearchRunnerNode.java
+++ b/src/main/java/org/codelibs/opensearch/runner/node/OpenSearchRunnerNode.java
@@ -27,10 +27,19 @@ import org.opensearch.node.Node;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.PluginInfo;
 
+/**
+ * Custom Node implementation for running OpenSearch instances in test environments.
+ */
 public class OpenSearchRunnerNode extends Node {
 
     private final Collection<Class<? extends Plugin>> plugins;
 
+    /**
+     * Constructs a new OpenSearchRunnerNode with the specified environment and plugins.
+     *
+     * @param tmpEnv the environment configuration
+     * @param classpathPlugins the collection of plugin classes to load
+     */
     public OpenSearchRunnerNode(final Environment tmpEnv, final Collection<Class<? extends Plugin>> classpathPlugins) {
         super(tmpEnv, classpathPlugins.stream().map(p -> {
             try {
@@ -43,6 +52,11 @@ public class OpenSearchRunnerNode extends Node {
         this.plugins = classpathPlugins;
     }
 
+    /**
+     * Gets the collection of plugin classes loaded by this node.
+     *
+     * @return the plugin classes
+     */
     public Collection<Class<? extends Plugin>> getPlugins() {
         return plugins;
     }


### PR DESCRIPTION
This update enhances code readability and maintainability by adding detailed Javadoc comments across multiple OpenSearch Runner classes. The documentation now explains the purpose, parameters, and return values for key constants, fields, methods, and constructors.

- Added Javadoc for `OpenSearchRunner`, including constants, configuration options, and helper methods.
- Documented constructors, cluster operations (`flush`, `refresh`, `upgrade`, `forceMerge`, etc.), and utility methods.
- Enhanced clarity in `OpenSearchRunnerException` with descriptions for constructors and getters.
- Added Javadoc to `OpenSearchCurl` for HTTP client utilities and JSON parser.
- Documented `OpenSearchRunnerNode` with details on plugin management and environment setup.

Benefits：
- Improves developer experience.
- Supports easier onboarding for new contributors.
- Aligns with best practices for public API documentation.