### PR TITLE
chore: bump OpenSearch to 3.7.0 and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+OpenSearch Runner is a utility library that runs OpenSearch clusters on a single JVM instance for development and testing. It can be used as an embedded OpenSearch instance in applications or for running test clusters.
+
+## Build and Development Commands
+
+### Build
+```bash
+mvn compile
+```
+
+### Run Tests
+```bash
+mvn test
+```
+
+### Run a Single Test
+```bash
+mvn test -Dtest=OpenSearchRunnerTest#test_runCluster
+```
+
+### Package
+```bash
+mvn package
+```
+
+### Run Standalone Cluster
+```bash
+# Default: 3 nodes on ports 9201-9203 (HTTP) and 9301-9303 (Transport)
+mvn exec:java
+
+# Custom configuration (e.g., 4 nodes)
+mvn exec:java -Dexec.args="-basePath es_home -numOfNode 4"
+```
+
+## Architecture
+
+### Core Components
+
+- **OpenSearchRunner** (`src/main/java/org/codelibs/opensearch/runner/OpenSearchRunner.java`): Main class that manages the lifecycle of OpenSearch nodes. Provides methods for starting/stopping nodes, performing operations (index, search, delete), and cluster management.
+
+- **OpenSearchRunnerNode** (`src/main/java/org/codelibs/opensearch/runner/node/OpenSearchRunnerNode.java`): Custom Node implementation for running OpenSearch instances.
+
+- **OpenSearchCurl** (`src/main/java/org/codelibs/opensearch/runner/net/OpenSearchCurl.java`): HTTP client utilities for interacting with the OpenSearch cluster.
+
+### Key Design Patterns
+
+1. **Builder Pattern**: The `OpenSearchRunner.Builder` interface allows customization of node settings during cluster setup.
+
+2. **Configs Class**: Fluent API for configuring cluster parameters (number of nodes, ports, paths, plugins).
+
+3. **Module/Plugin System**: Supports loading OpenSearch modules and plugins dynamically via `moduleTypes` and `pluginTypes` configuration.
+
+### Default Configuration
+
+- Base HTTP Port: 9200 (node N listens on 9200+N → 9201-9203 for 3 nodes)
+- Cluster Name: "opensearch-runner"
+- Data Directory: `es_home/data`
+- Config Directory: `es_home/config`
+- Logs Directory: `es_home/logs`
+
+## Gotchas
+
+- If `basePath` is not set, the runner creates a temp directory (`Files.createTempDirectory("opensearch-cluster")`) — data is not persisted across runs unless `basePath` is specified.
+- Single-node clusters (`numOfNode == 1`) use special discovery settings; multi-node defaults differ.
+
+### Testing Approach
+
+Tests use JUnit 4 and follow the pattern:
+1. Create runner instance in `setUp()`
+2. Build cluster with custom configuration
+3. Perform operations and assertions
+4. Clean up in `tearDown()`
+
+## Dependencies
+
+- OpenSearch 3.7.0
+- Lucene 10.4.0
+- Log4j 2.25.4
+- Java 21 required

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ OpenSearch Runner is a utility library that allows you to run OpenSearch cluster
 
 - Java 21 or higher
 - Maven 3.6 or higher
-- OpenSearch 3.3.0 (current development version)
+- OpenSearch 3.7.0
 
 ## Installation
 
@@ -33,7 +33,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.codelibs.opensearch</groupId>
     <artifactId>opensearch-runner</artifactId>
-    <version>3.3.0.0</version>
+    <version>3.7.0.0</version>
 </dependency>
 ```
 
@@ -43,7 +43,7 @@ For testing purposes, use `test` scope:
 <dependency>
     <groupId>org.codelibs.opensearch</groupId>
     <artifactId>opensearch-runner</artifactId>
-    <version>3.3.0.0</version>
+    <version>3.7.0.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -51,10 +51,10 @@ For testing purposes, use `test` scope:
 ### Gradle
 
 ```gradle
-implementation 'org.codelibs.opensearch:opensearch-runner:3.3.0.0'
+implementation 'org.codelibs.opensearch:opensearch-runner:3.7.0.0'
 
 // For testing
-testImplementation 'org.codelibs.opensearch:opensearch-runner:3.3.0.0'
+testImplementation 'org.codelibs.opensearch:opensearch-runner:3.7.0.0'
 ```
 
 ## Quick Start

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-runner</artifactId>
-	<version>3.6.0.1-SNAPSHOT</version>
+	<version>3.7.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>OpenSearch Runner</name>
 	<description>OpenSearch Runner is a utility for running and managing OpenSearch clusters locally.</description>
@@ -36,9 +36,9 @@
   </scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<opensearch.version>3.6.0</opensearch.version>
+		<opensearch.version>3.7.0</opensearch.version>
 		<lucene.version>10.4.0</lucene.version>
-		<log4j.version>2.25.3</log4j.version>
+		<log4j.version>2.25.4</log4j.version>
 		<jna.version>5.16.0</jna.version>
 		<jts-core.version>1.15.0</jts-core.version>
 		<spatial4j.version>0.7</spatial4j.version>


### PR DESCRIPTION
## Summary
Upgrades OpenSearch Runner to target OpenSearch 3.7.0, bumps Log4j, and adds a CLAUDE.md guide for the repository.

## Changes Made
- Bump `opensearch.version` from 3.6.0 to 3.7.0 in `pom.xml`
- Bump `log4j.version` from 2.25.3 to 2.25.4
- Update project version to `3.7.0.0-SNAPSHOT`
- Update README installation snippets (Maven/Gradle) to `3.7.0.0` and requirement to OpenSearch 3.7.0
- Add `CLAUDE.md` documenting build/dev commands, architecture, default configuration, and testing approach

## Testing
- `mvn test` to verify the cluster runs against OpenSearch 3.7.0

## Breaking Changes
- None

## Additional Notes
- This is mainly a dependency/version bump; reviewers should confirm CI passes against the new OpenSearch and Log4j versions.