### PR TITLE
build: attach sources and javadoc jars to release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,18 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.11.2</version>
 				<configuration>
@@ -90,6 +102,14 @@
 					<docencoding>UTF-8</docencoding>
 					<charset>UTF-8</charset>
 				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.mycila</groupId>


### PR DESCRIPTION
## Summary
Sources and javadoc jars were not being built when releasing with the maven-release-plugin. The `release:perform` goal runs `deploy`, but the POM had no `maven-source-plugin` and the `maven-javadoc-plugin` had no `jar` goal execution, so neither artifact was generated or attached. The super POM `release-profile` that used to handle this automatically is no longer available in current Maven versions, so the executions need to be declared explicitly.

## Changes Made
- Added `maven-source-plugin` 3.3.1 with an `attach-sources` execution bound to the `jar-no-fork` goal
- Added an `attach-javadocs` execution with the `jar` goal to the existing `maven-javadoc-plugin` configuration

## Testing
- Ran `mvn package -DskipTests -Dgpg.skip=true` and confirmed that `opensearch-runner-3.7.0.0-SNAPSHOT-sources.jar` and `opensearch-runner-3.7.0.0-SNAPSHOT-javadoc.jar` are generated in `target/` alongside the main jar

## Additional Notes
- Both jars are now built on every `mvn package`, which adds a small overhead to regular builds. Since they are signed by the GPG plugin at the `verify` phase and included in Central publishing, always attaching them is the standard setup for Central-published projects.