### PR TITLE
chore: bump OpenSearch to 3.8.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Tests use JUnit 4 and follow the pattern:
 
 ## Dependencies
 
-- OpenSearch 3.7.0
-- Lucene 10.4.0
+- OpenSearch 3.8.0
+- Lucene 10.5.0
 - Log4j 2.25.4
 - Java 21 required

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ OpenSearch Runner is a utility library that allows you to run OpenSearch cluster
 
 - Java 21 or higher
 - Maven 3.6 or higher
-- OpenSearch 3.7.0
+- OpenSearch 3.8.0
 
 ## Installation
 
@@ -33,7 +33,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.codelibs.opensearch</groupId>
     <artifactId>opensearch-runner</artifactId>
-    <version>3.7.0.0</version>
+    <version>3.8.0.0</version>
 </dependency>
 ```
 
@@ -43,7 +43,7 @@ For testing purposes, use `test` scope:
 <dependency>
     <groupId>org.codelibs.opensearch</groupId>
     <artifactId>opensearch-runner</artifactId>
-    <version>3.7.0.0</version>
+    <version>3.8.0.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -51,10 +51,10 @@ For testing purposes, use `test` scope:
 ### Gradle
 
 ```gradle
-implementation 'org.codelibs.opensearch:opensearch-runner:3.7.0.0'
+implementation 'org.codelibs.opensearch:opensearch-runner:3.8.0.0'
 
 // For testing
-testImplementation 'org.codelibs.opensearch:opensearch-runner:3.7.0.0'
+testImplementation 'org.codelibs.opensearch:opensearch-runner:3.8.0.0'
 ```
 
 ## Quick Start

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-runner</artifactId>
-	<version>3.7.0.1-SNAPSHOT</version>
+	<version>3.8.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>OpenSearch Runner</name>
 	<description>OpenSearch Runner is a utility for running and managing OpenSearch clusters locally.</description>
@@ -36,8 +36,8 @@
   </scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<opensearch.version>3.7.0</opensearch.version>
-		<lucene.version>10.4.0</lucene.version>
+		<opensearch.version>3.8.0</opensearch.version>
+		<lucene.version>10.5.0</lucene.version>
 		<log4j.version>2.25.4</log4j.version>
 		<jna.version>5.16.0</jna.version>
 		<jts-core.version>1.15.0</jts-core.version>


### PR DESCRIPTION
## Summary

Bumps the OpenSearch dependency from 3.7.0 to 3.8.0 and updates the project version accordingly.

## Changes Made

- `opensearch.version`: 3.7.0 -> 3.8.0
- `lucene.version`: 10.4.0 -> 10.5.0, matching the Lucene version that OpenSearch 3.8.0 depends on
- Project version: 3.7.0.1-SNAPSHOT -> 3.8.0.0-SNAPSHOT
- README: installation snippets (Maven/Gradle) and the requirements section updated to 3.8.0.0 / OpenSearch 3.8.0
- CLAUDE.md: dependency list updated to OpenSearch 3.8.0 / Lucene 10.5.0

The other pinned versions (Log4j 2.25.4, JNA 5.16.0, jts-core 1.15.0, spatial4j 0.7) are unchanged in OpenSearch 3.8.0, so they were left as-is. `download.sh` reads `opensearch.version` from the POM and needed no change.

## Testing

`mvn test` passes locally: 142 tests, 0 failures, 0 errors. No source changes were needed, so there are no API incompatibilities with 3.8.0.

## Breaking Changes

None in this repository. Users upgrading will pick up the OpenSearch 3.8.0 core, so any behavior changes in that release apply transitively.

## Additional Notes

Nothing surprising here - the only non-mechanical part was the Lucene bump, which was taken from the OpenSearch 3.8.0 POM rather than guessed.
