### PR TITLE
build(pom): bump central-publishing-maven-plugin to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## Summary
Bumps the `central-publishing-maven-plugin` used for releasing artifacts to Maven Central from `0.7.0` to `0.11.0`.

## Changes Made
- Updated `central-publishing-maven-plugin` version in `pom.xml` from `0.7.0` to `0.11.0`

## Testing
- N/A (build plugin version bump, no code changes)

## Breaking Changes
- None

## Additional Notes
- Picks up upstream fixes/improvements from the plugin's newer releases for publishing to Maven Central.
